### PR TITLE
Compatibility with newer base where (<>) is exported in Prelude

### DIFF
--- a/Language/Go/Pretty.hs
+++ b/Language/Go/Pretty.hs
@@ -12,6 +12,7 @@ module Language.Go.Pretty (
 
 -- TODO: tabwriter-like alignment of fields.
 
+import Prelude hiding ((<>))
 import Data.List
 import Data.Maybe (isJust)
 import Text.PrettyPrint


### PR DESCRIPTION
Addresses this compile error:

```
Language/Go/Pretty.hs:207:81: error:
        Ambiguous occurrence ‘<>’
        It could refer to either ‘Prelude.<>’,
                                 imported from ‘Prelude’ at Language/Go/Pretty.hs:9:8-25
                                 (and originally defined in ‘GHC.Base’)
                              or ‘Text.PrettyPrint.<>’,
                                 imported from ‘Text.PrettyPrint’ at Language/Go/Pretty.hs:17:1-23
                                 (and originally defined in ‘Text.PrettyPrint.HughesPJ’)
        |
    207 |   pretty (GoForThree init cond incr) = pretty init <> semi <+> prettyMaybe cond <> semi <+> pretty incr
        |                                                                                 ^^
```